### PR TITLE
Demonstrate Apollo + React

### DIFF
--- a/webviews/README.md
+++ b/webviews/README.md
@@ -28,3 +28,6 @@ export default {
 - Replace `plugin:@typescript-eslint/recommended` to `plugin:@typescript-eslint/recommended-type-checked` or `plugin:@typescript-eslint/strict-type-checked`
 - Optionally add `plugin:@typescript-eslint/stylistic-type-checked`
 - Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and add `plugin:react/recommended` & `plugin:react/jsx-runtime` to the `extends` list
+
+## Apollo
+See [Apollo extension for VS Code](https://www.apollographql.com/docs/devtools/editor-plugins/) for instructions on setting up Apollo with VS Code.

--- a/webviews/apollo.config.cjs
+++ b/webviews/apollo.config.cjs
@@ -1,0 +1,13 @@
+// For https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo
+export default {
+  client: {
+    service: {
+      name: 'Symphony API',
+      url:
+        import.meta.env.VITE_APP_ATLAS_GRAPHQL_ENDPOINT ||
+        'https://acai-resources-preview---symphony-api-svc-prod-25c5xl4maa-uk.a.run.app/graphql/',
+    },
+    // Files processed by the extension
+    includes: ['src/**/*.tsx'],
+  },
+}

--- a/webviews/package.json
+++ b/webviews/package.json
@@ -12,9 +12,11 @@
     "preview": "pnpm run vite preview"
   },
   "dependencies": {
+    "@apollo/client": "^3.11.1",
     "@vscode/webview-ui-toolkit": "^1.4.0",
     "dompurify": "^3.0.9",
     "framer-motion": "^11.0.15",
+    "graphql": "^16.9.0",
     "marked": "^12.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/webviews/src/ACAIResourceView/ACAIResourceView.tsx
+++ b/webviews/src/ACAIResourceView/ACAIResourceView.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { gql } from '@apollo/client'
 import "./ACAIResourceView.css";
 
 declare global {
@@ -9,6 +10,15 @@ declare global {
 // Ensure that the acquireVsCodeApi function is defined in the window object
 const vscode = window.acquireVsCodeApi ? window.acquireVsCodeApi() : undefined;
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const QUERY = gql`
+query ACAIRecords {
+  acaiRecords {
+    label
+    uri
+  }
+}
+`
 const ACAIResourceView: React.FC = () => {
   const [selectedOption, setSelectedOption] = useState("");
   const [options, setOptions] = useState<string[]>([]);

--- a/webviews/src/ACAIResourceView/ACAIResourceView.tsx
+++ b/webviews/src/ACAIResourceView/ACAIResourceView.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react";
-import { gql } from '@apollo/client'
+import { useQuery, gql } from '@apollo/client'
+
 import "./ACAIResourceView.css";
 
 declare global {
@@ -10,14 +11,14 @@ declare global {
 // Ensure that the acquireVsCodeApi function is defined in the window object
 const vscode = window.acquireVsCodeApi ? window.acquireVsCodeApi() : undefined;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const QUERY = gql`
-query ACAIRecords {
-  acaiRecords {
-    label
-    uri
+
+const ACAI_RECORDS_IN_PASSAGE = gql`
+  query ACAIRecordsInPassage($acaiRecordsFilters: AcaiRecordFilter) {
+    acaiRecords(filters: $acaiRecordsFilters) {
+      label
+      uri
+    }
   }
-}
 `
 const ACAIResourceView: React.FC = () => {
   const [selectedOption, setSelectedOption] = useState("");
@@ -45,6 +46,20 @@ const ACAIResourceView: React.FC = () => {
       value: event.target.value,
     });
   };
+  const queryVariables = {
+    "acaiRecordsFilters": {
+      "scriptureReference": {
+        "usfmRef": "JHN 6:1",
+        "textualEdition": "SBLGNT"
+      }
+    }
+  }
+  const { loading, error, data } = useQuery(ACAI_RECORDS_IN_PASSAGE, {
+    variables: queryVariables,
+  })
+
+  if (loading) return <p>Loading...</p>
+  if (error) return <p>Error : {error.message}</p>
 
   return (
     <div>
@@ -59,6 +74,15 @@ const ACAIResourceView: React.FC = () => {
       <h1>ACAI Resources</h1>
       <p>Welcome to the ACAI Resources tool!</p>
       <p>Selected option: {selectedOption}</p>
+      {data && data.acaiRecords && (
+        <ul>
+          {data.acaiRecords.map((record: any) => (
+            <li key={record.uri}>
+              {record.label} - {record.uri}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };

--- a/webviews/src/ACAIResourceView/index.tsx
+++ b/webviews/src/ACAIResourceView/index.tsx
@@ -3,8 +3,19 @@ import ReactDOM from "react-dom/client";
 import ACAIResourceView from "./ACAIResourceView";
 import "../index.css";
 
+import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client'
+
+const client = new ApolloClient({
+  uri:
+    import.meta.env.VITE_APP_ATLAS_GRAPHQL_ENDPOINT ||
+    'https://acai-resources-preview---symphony-api-svc-prod-25c5xl4maa-uk.a.run.app/graphql/',
+  cache: new InMemoryCache(),
+})
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <ACAIResourceView />
-  </React.StrictMode>
+  <ApolloProvider client={client}>
+    <React.StrictMode>
+      <ACAIResourceView />
+    </React.StrictMode>
+  </ApolloProvider>
 );


### PR DESCRIPTION
Two main aims here:

1) Demonstrate querying the ATLAS GraphQL endpoint:

<img width="415" alt="image" src="https://github.com/user-attachments/assets/18fa9260-ea9a-49a8-bdf0-5a540f902c0b">

2) Show how the [Apollo extension for VS Code](https://www.apollographql.com/docs/devtools/editor-plugins/) can help with syntax highlighting, autocomplete, etc:

_Auto complete fields_:

<img width="734" alt="image" src="https://github.com/user-attachments/assets/f3fd5852-f13d-410b-800d-7508d84063ac">

_Validate fields_:

<img width="930" alt="image" src="https://github.com/user-attachments/assets/2ef0cd9d-204e-4e40-8d98-d1114aeb48c7">

_Explore GraphQL type definitions_:

<img width="930" alt="image" src="https://github.com/user-attachments/assets/83bc9009-035e-4772-9494-4141fb0b23cc">

_Browse schema from within VS Code_:

<img width="930" alt="image" src="https://github.com/user-attachments/assets/cf7bea79-72c8-4e1a-aa79-049804c439ec">
